### PR TITLE
feat: Core 4912 support common blob to get from ec2 role

### DIFF
--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -18,11 +18,11 @@ package commonblobgo
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"io"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
@@ -65,7 +65,6 @@ func newAWSCloudStorage(
 	if err != nil {
 		return nil, err
 	}
-
 
 	bucket, err := s3blob.OpenBucket(ctx, awsSession, bucketName, nil)
 	if err != nil {
@@ -152,9 +151,10 @@ func (ts *AWSCloudStorage) Close() {
 func (ts *AWSCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
+	method string,
 	expiry time.Duration,
 ) (string, error) {
-	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry})
+	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry, Method: method})
 }
 
 func (ts *AWSCloudStorage) Write(

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -18,6 +18,7 @@ package commonblobgo
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"io"
 	"time"
 
@@ -56,10 +57,15 @@ func newAWSCloudStorage(
 		}
 	}
 
+	// Create default credentials. Default credential wll get the credential from environment provider, shared
+	// credential provider, or ec2 role
+	awsConfig.Credentials = defaults.CredChain(&awsConfig, defaults.Handlers())
+
 	awsSession, err := session.NewSession(&awsConfig)
 	if err != nil {
 		return nil, err
 	}
+
 
 	bucket, err := s3blob.OpenBucket(ctx, awsSession, bucketName, nil)
 	if err != nil {

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -19,7 +19,6 @@ package commonblobgo
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
@@ -151,10 +150,16 @@ func (ts *AWSCloudStorage) Close() {
 func (ts *AWSCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
-	method string,
-	expiry time.Duration,
+	opts *SignedURLOption,
 ) (string, error) {
-	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry, Method: method})
+	options := &blob.SignedURLOptions{
+		Expiry:                   opts.Expiry,
+		Method:                   opts.Method,
+		ContentType:              opts.ContentType,
+		EnforceAbsentContentType: opts.EnforceAbsentContentType,
+	}
+
+	return ts.bucket.SignedURL(context.Background(), key, options)
 }
 
 func (ts *AWSCloudStorage) Write(

--- a/aws-test-cloud-storage.go
+++ b/aws-test-cloud-storage.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
@@ -207,10 +206,15 @@ func (ts *AWSTestCloudStorage) Close() {
 func (ts *AWSTestCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
-	method string,
-	expiry time.Duration,
+	opts *SignedURLOption,
 ) (string, error) {
-	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry, Method: method})
+	options := &blob.SignedURLOptions{
+		Expiry:                   opts.Expiry,
+		Method:                   opts.Method,
+		ContentType:              opts.ContentType,
+		EnforceAbsentContentType: opts.EnforceAbsentContentType,
+	}
+	return ts.bucket.SignedURL(context.Background(), key, options)
 }
 
 func (ts *AWSTestCloudStorage) Write(

--- a/aws-test-cloud-storage.go
+++ b/aws-test-cloud-storage.go
@@ -18,6 +18,7 @@ package commonblobgo
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"io"
 	"strings"
 	"time"
@@ -58,6 +59,10 @@ func newAWSTestCloudStorage(
 			S3ForcePathStyle: aws.Bool(true), //path style for localstack
 		}
 	}
+
+	// Create default credentials. Default credential wll get the credential from environment provider, shared
+	// credential provider, or ec2 role
+	awsConfig.Credentials = defaults.CredChain(&awsConfig, defaults.Handlers())
 
 	awsSession, err := session.NewSession(&awsConfig)
 	if err != nil {

--- a/aws-test-cloud-storage.go
+++ b/aws-test-cloud-storage.go
@@ -18,12 +18,12 @@ package commonblobgo
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"io"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
@@ -207,9 +207,10 @@ func (ts *AWSTestCloudStorage) Close() {
 func (ts *AWSTestCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
+	method string,
 	expiry time.Duration,
 ) (string, error) {
-	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry})
+	return ts.bucket.SignedURL(context.Background(), key, &blob.SignedURLOptions{Expiry: expiry, Method: method})
 }
 
 func (ts *AWSTestCloudStorage) Write(

--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -101,7 +101,7 @@ type CloudStorage interface {
 	Delete(ctx context.Context, key string) error
 	CreateBucket(ctx context.Context, bucketPrefix string, expirationTimeDays int64) error
 	Close()
-	GetSignedURL(ctx context.Context, key string, method string, expiry time.Duration) (string, error)
+	GetSignedURL(ctx context.Context, key string, opts *SignedURLOption) (string, error)
 	Write(ctx context.Context, key string, body []byte, contentType *string) error
 	Attributes(ctx context.Context, key string) (*Attributes, error)
 	GetReader(ctx context.Context, key string) (io.ReadCloser, error)
@@ -168,4 +168,11 @@ type Attributes struct {
 	Size int64
 	// MD5 is an MD5 hash of the blob contents or nil if not available.
 	MD5 []byte
+}
+
+type SignedURLOption struct {
+	Method                   string
+	Expiry                   time.Duration
+	ContentType              string
+	EnforceAbsentContentType bool
 }

--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -101,7 +101,7 @@ type CloudStorage interface {
 	Delete(ctx context.Context, key string) error
 	CreateBucket(ctx context.Context, bucketPrefix string, expirationTimeDays int64) error
 	Close()
-	GetSignedURL(ctx context.Context, key string, expiry time.Duration) (string, error)
+	GetSignedURL(ctx context.Context, key string, method string, expiry time.Duration) (string, error)
 	Write(ctx context.Context, key string, body []byte, contentType *string) error
 	Attributes(ctx context.Context, key string) (*Attributes, error)
 	GetReader(ctx context.Context, key string) (io.ReadCloser, error)

--- a/cloud-storage_test.go
+++ b/cloud-storage_test.go
@@ -319,7 +319,14 @@ func (s *Suite) TestGetSignedURL() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(storedBody)
 
-	url, err := s.storage.GetSignedURL(s.ctx, fileName, "GET", time.Hour)
+	options := &SignedURLOption{
+		Expiry:                   time.Hour,
+		Method:                   "GET",
+		ContentType:              "",
+		EnforceAbsentContentType: false,
+	}
+
+	url, err := s.storage.GetSignedURL(s.ctx, fileName, options)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(url)
 }

--- a/cloud-storage_test.go
+++ b/cloud-storage_test.go
@@ -319,7 +319,7 @@ func (s *Suite) TestGetSignedURL() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(storedBody)
 
-	url, err := s.storage.GetSignedURL(s.ctx, fileName, time.Hour)
+	url, err := s.storage.GetSignedURL(s.ctx, fileName, "GET", time.Hour)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(url)
 }

--- a/gcp-cloud-storage-explicit.go
+++ b/gcp-cloud-storage-explicit.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -175,12 +174,13 @@ func (ts *ExplicitGCPCloudStorage) Close() {
 func (ts *ExplicitGCPCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
+	method string,
 	expiry time.Duration,
 ) (string, error) {
 	return storage.SignedURL(ts.bucketName, key, &storage.SignedURLOptions{
 		GoogleAccessID: ts.googleAccessID,
 		PrivateKey:     ts.privateKey,
-		Method:         http.MethodGet,
+		Method:         method,
 		Expires:        time.Now().Add(expiry).UTC(),
 	})
 }

--- a/gcp-cloud-storage-explicit.go
+++ b/gcp-cloud-storage-explicit.go
@@ -174,14 +174,13 @@ func (ts *ExplicitGCPCloudStorage) Close() {
 func (ts *ExplicitGCPCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
-	method string,
-	expiry time.Duration,
+	opts *SignedURLOption,
 ) (string, error) {
 	return storage.SignedURL(ts.bucketName, key, &storage.SignedURLOptions{
 		GoogleAccessID: ts.googleAccessID,
 		PrivateKey:     ts.privateKey,
-		Method:         method,
-		Expires:        time.Now().Add(expiry).UTC(),
+		Method:         opts.Method,
+		Expires:        time.Now().Add(opts.Expiry).UTC(),
 	})
 }
 

--- a/gcp-cloud-storage-implicit.go
+++ b/gcp-cloud-storage-implicit.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 
 	compMeta "cloud.google.com/go/compute/metadata"
@@ -176,6 +175,7 @@ func (ts *ImplicitGCPCloudStorage) Close() {
 func (ts *ImplicitGCPCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
+	method string,
 	expiry time.Duration,
 ) (string, error) {
 	// we use GCP IAM client to sign bytes body(url)
@@ -184,7 +184,7 @@ func (ts *ImplicitGCPCloudStorage) GetSignedURL(
 
 	options := &storage.SignedURLOptions{
 		GoogleAccessID: ts.serviceAccountEmail,
-		Method:         http.MethodGet,
+		Method:         method,
 		Expires:        time.Now().Add(expiry).UTC(),
 		SignBytes: func(b []byte) ([]byte, error) {
 			req := &credentialspb.SignBlobRequest{

--- a/gcp-cloud-storage-implicit.go
+++ b/gcp-cloud-storage-implicit.go
@@ -175,8 +175,7 @@ func (ts *ImplicitGCPCloudStorage) Close() {
 func (ts *ImplicitGCPCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
-	method string,
-	expiry time.Duration,
+	opts *SignedURLOption,
 ) (string, error) {
 	// we use GCP IAM client to sign bytes body(url)
 	// for details read https://github.com/googleapis/google-cloud-go/issues/1130#issuecomment-484236791
@@ -184,8 +183,8 @@ func (ts *ImplicitGCPCloudStorage) GetSignedURL(
 
 	options := &storage.SignedURLOptions{
 		GoogleAccessID: ts.serviceAccountEmail,
-		Method:         method,
-		Expires:        time.Now().Add(expiry).UTC(),
+		Method:         opts.Method,
+		Expires:        time.Now().Add(opts.Expiry).UTC(),
 		SignBytes: func(b []byte) ([]byte, error) {
 			req := &credentialspb.SignBlobRequest{
 				Payload: b,

--- a/gcp-test-cloud-storage.go
+++ b/gcp-test-cloud-storage.go
@@ -205,8 +205,7 @@ func (ts *GCPTestCloudStorage) Close() {
 func (ts *GCPTestCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
-	method string,
-	expiry time.Duration,
+	opts *SignedURLOption,
 ) (string, error) {
 	return fmt.Sprintf("http://%s/%s/%s", ts.host, ts.bucketName, key), nil
 }

--- a/gcp-test-cloud-storage.go
+++ b/gcp-test-cloud-storage.go
@@ -205,6 +205,7 @@ func (ts *GCPTestCloudStorage) Close() {
 func (ts *GCPTestCloudStorage) GetSignedURL(
 	ctx context.Context,
 	key string,
+	method string,
 	expiry time.Duration,
 ) (string, error) {
 	return fmt.Sprintf("http://%s/%s/%s", ts.host, ts.bucketName, key), nil


### PR DESCRIPTION
feat: Core 4912 support common blob to get from ec2 role

Additional fix:
- Support signed url for other method than GET

BREAKING CHANGES
This will need to change the implementation on service level when updating to this common-blob-go version for get signed url