### PR TITLE
fix: remove default creds chain

### DIFF
--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
@@ -55,10 +54,6 @@ func newAWSCloudStorage(
 			S3ForcePathStyle: aws.Bool(true), //path style for localstack
 		}
 	}
-
-	// Create default credentials. Default credential wll get the credential from environment provider, shared
-	// credential provider, or ec2 role
-	awsConfig.Credentials = defaults.CredChain(&awsConfig, defaults.Handlers())
 
 	awsSession, err := session.NewSession(&awsConfig)
 	if err != nil {

--- a/aws-test-cloud-storage.go
+++ b/aws-test-cloud-storage.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
@@ -58,10 +57,6 @@ func newAWSTestCloudStorage(
 			S3ForcePathStyle: aws.Bool(true), //path style for localstack
 		}
 	}
-
-	// Create default credentials. Default credential wll get the credential from environment provider, shared
-	// credential provider, or ec2 role
-	awsConfig.Credentials = defaults.CredChain(&awsConfig, defaults.Handlers())
 
 	awsSession, err := session.NewSession(&awsConfig)
 	if err != nil {


### PR DESCRIPTION
fix: remove default creds chain

by default, initiate new session using aws-go-sdk will already use web token identity

`// Web identity environment variables
setFromEnvVal(&cfg.WebIdentityTokenFilePath, webIdentityTokenFilePathEnvKey)`

The environment variable `AWS_WEB_IDENTITY_TOKEN_FILE` will be injected to instance 