### PR TITLE
feat: enable transfer accelerate for aws s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ storage, err := storage, err := NewCloudStorage(
      </details>
  
  * gcpStorageEmulatorHost string : GCP storage host. Used only from tests(required if bucketProvider==`gcp` and isTesting == `true`)
- * opts CloudStorageOption: Cloud storage option to enable/disable some feature of cloud storage.
-   * awsEnableS3Accelerate (default: false) : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**. 
-     Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
 
 To enable cloud storage additional features:   
 ```go

--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ storage, err := storage, err := NewCloudStorage(
  
  * gcpStorageEmulatorHost string : GCP storage host. Used only from tests(required if bucketProvider==`gcp` and isTesting == `true`)
 
+To enable accelerate endpoint in AWS S3 please use `NewCloudStorageV2`:
+
+```go
+storage, err := storage, err := NewCloudStorageV2(
+    ctx,
+    isTesting,
+    bucketProvider,
+    bucketName,
+    awsS3Endpoint,
+    awsS3Region,
+    awsS3AccessKeyID,
+    awsS3SecretAccessKey,
+    awsEnableAccelerate,
+    gcpCredentialsJSON,
+    gcpStorageEmulatorHost,
+)
+```
+
+Additional new parameter in ``NewCloudStorageV2`` :
+* awsEnableAccelerate : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**.
+
+Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
+
 ### Available methods :
 ```go
 type CloudStorage interface {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ storage, err := storage, err := NewCloudStorage(
     awsS3SecretAccessKey,
     gcpCredentialsJSON,
     gcpStorageEmulatorHost,
-    opts,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ storage, err := storage, err := NewCloudStorage(
    * awsEnableS3Accelerate (default: false) : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**. 
      Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
 
+To enable cloud storage additional features:   
+```go
+storage, err := storage, err := NewCloudStorageWithOption(
+    ctx,
+    isTesting,
+    bucketProvider,
+    bucketName,
+    opts,
+)
+```
+Cloud-specific parameter such as `awsRegion`, `gcpStorageEmulatorHost`, etc. has been moved to `opts CloudStorageOption`.
+
+Supported additional cloud storage feature:
+* `opts.AWSEnableS3Accelerate` (default: false) : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**.
+Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
+
+
+
 ### Available methods :
 ```go
 type CloudStorage interface {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ storage, err := storage, err := NewCloudStorage(
     awsS3SecretAccessKey,
     gcpCredentialsJSON,
     gcpStorageEmulatorHost,
+    opts,
 )
 ```
 
@@ -54,29 +55,9 @@ storage, err := storage, err := NewCloudStorage(
      </details>
  
  * gcpStorageEmulatorHost string : GCP storage host. Used only from tests(required if bucketProvider==`gcp` and isTesting == `true`)
-
-To enable accelerate endpoint in AWS S3 please use `NewCloudStorageV2`:
-
-```go
-storage, err := storage, err := NewCloudStorageV2(
-    ctx,
-    isTesting,
-    bucketProvider,
-    bucketName,
-    awsS3Endpoint,
-    awsS3Region,
-    awsS3AccessKeyID,
-    awsS3SecretAccessKey,
-    awsEnableAccelerate,
-    gcpCredentialsJSON,
-    gcpStorageEmulatorHost,
-)
-```
-
-Additional new parameter in ``NewCloudStorageV2`` :
-* awsEnableAccelerate : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**.
-
-Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
+ * opts CloudStorageOption: Cloud storage option to enable/disable some feature of cloud storage.
+   * awsEnableS3Accelerate (default: false) : a boolean that indicate S3 bucket use accelerate endpoint. **Not available in testing using localstack or using path-style S3 endpoint**. 
+     Note: make sure to enable transfer accelerate in S3 bucket, please refer to [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html).
 
 ### Available methods :
 ```go

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -18,7 +18,6 @@ package commonblobgo
 
 import (
 	"context"
-	"errors"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -39,7 +38,7 @@ func newAWSCloudStorage(
 	s3Endpoint string,
 	s3Region string,
 	bucketName string,
-	enableAccelerateEndpoint bool,
+	opts *CloudStorageOption,
 ) (*AWSCloudStorage, error) {
 	// create vanilla AWS client
 	var awsConfig aws.Config
@@ -48,17 +47,14 @@ func newAWSCloudStorage(
 		awsConfig = aws.Config{
 			Endpoint:         aws.String(s3Endpoint),
 			Region:           aws.String(s3Region),
-			S3ForcePathStyle: aws.Bool(!enableAccelerateEndpoint), //path style for localstack
+			S3ForcePathStyle: aws.Bool(true),
 		}
 	} else {
 		awsConfig = aws.Config{
 			Region: aws.String(s3Region),
 		}
-	}
-	if enableAccelerateEndpoint {
-		awsConfig.S3UseAccelerate = aws.Bool(enableAccelerateEndpoint)
-		if s3Endpoint != "" {
-			return nil, errors.New("cannot use accelerate with path style S3 url")
+		if opts != nil {
+			awsConfig.S3UseAccelerate = aws.Bool(opts.AWSEnableS3Accelerate)
 		}
 	}
 

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -18,6 +18,7 @@ package commonblobgo
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,6 +39,7 @@ func newAWSCloudStorage(
 	s3Endpoint string,
 	s3Region string,
 	bucketName string,
+	enableAccelerateEndpoint bool,
 ) (*AWSCloudStorage, error) {
 	// create vanilla AWS client
 	var awsConfig aws.Config
@@ -46,12 +48,17 @@ func newAWSCloudStorage(
 		awsConfig = aws.Config{
 			Endpoint:         aws.String(s3Endpoint),
 			Region:           aws.String(s3Region),
-			S3ForcePathStyle: aws.Bool(true), //path style for localstack
+			S3ForcePathStyle: aws.Bool(!enableAccelerateEndpoint), //path style for localstack
 		}
 	} else {
 		awsConfig = aws.Config{
-			Region:           aws.String(s3Region),
-			S3ForcePathStyle: aws.Bool(true), //path style for localstack
+			Region: aws.String(s3Region),
+		}
+	}
+	if enableAccelerateEndpoint {
+		awsConfig.S3UseAccelerate = aws.Bool(enableAccelerateEndpoint)
+		if s3Endpoint != "" {
+			return nil, errors.New("cannot use accelerate with path style S3 url")
 		}
 	}
 

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -38,7 +38,7 @@ func newAWSCloudStorage(
 	s3Endpoint string,
 	s3Region string,
 	bucketName string,
-	opts *CloudStorageOption,
+	accelerateEndpoint *bool,
 ) (*AWSCloudStorage, error) {
 	// create vanilla AWS client
 	var awsConfig aws.Config
@@ -53,8 +53,8 @@ func newAWSCloudStorage(
 		awsConfig = aws.Config{
 			Region: aws.String(s3Region),
 		}
-		if opts != nil {
-			awsConfig.S3UseAccelerate = aws.Bool(opts.AWSEnableS3Accelerate)
+		if accelerateEndpoint != nil {
+			awsConfig.S3UseAccelerate = accelerateEndpoint
 		}
 	}
 

--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -40,54 +40,63 @@ func NewCloudStorage(
 
 	gcpCredentialsJSON string,
 	gcpStorageEmulatorHost string,
-
-	opts ...*CloudStorageOption,
 ) (CloudStorage, error) {
+	return NewCloudStorageWithOption(ctx, isTesting, bucketProvider, bucketName, &CloudStorageOption{
+		AWSS3Endpoint:          awsS3Endpoint,
+		AWSS3Region:            awsS3Region,
+		AWSS3AccessKeyID:       awsS3AccessKeyID,
+		AWSS3SecretAccessKey:   awsS3SecretAccessKey,
+		AWSEnableS3Accelerate:  false,
+		GCPCredentialsJSON:     gcpCredentialsJSON,
+		GCPStorageEmulatorHost: gcpStorageEmulatorHost,
+	})
+}
 
-	cloudStorageOpt := mergeOpts(opts...)
-
+//nolint:funlen
+func NewCloudStorageWithOption(ctx context.Context, isTesting bool, bucketProvider, bucketName string, opts ...*CloudStorageOption) (CloudStorage, error) {
+	cloudStorageOpts := mergeOpts(opts...)
 	switch bucketProvider {
 	case "", "aws":
 		// 3-rd party library uses global variables
-		if awsS3AccessKeyID != "" {
-			err := os.Setenv("AWS_ACCESS_KEY_ID", awsS3AccessKeyID)
+		if cloudStorageOpts.AWSS3AccessKeyID != "" {
+			err := os.Setenv("AWS_ACCESS_KEY_ID", cloudStorageOpts.AWSS3AccessKeyID)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		// 3-rd party library uses global variables
-		if awsS3SecretAccessKey != "" {
-			err := os.Setenv("AWS_SECRET_ACCESS_KEY", awsS3SecretAccessKey)
+		if cloudStorageOpts.AWSS3SecretAccessKey != "" {
+			err := os.Setenv("AWS_SECRET_ACCESS_KEY", cloudStorageOpts.AWSS3SecretAccessKey)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		if isTesting {
-			return newAWSTestCloudStorage(ctx, awsS3Endpoint, awsS3Region, bucketName)
+			return newAWSTestCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketProvider)
 		}
 
-		return newAWSCloudStorage(ctx, awsS3Endpoint, awsS3Region, bucketName, cloudStorageOpt)
+		return newAWSCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketProvider, &cloudStorageOpts.AWSEnableS3Accelerate)
 
 	case "gcp":
 		if isTesting {
-			err := os.Setenv("STORAGE_EMULATOR_HOST", gcpStorageEmulatorHost)
+			err := os.Setenv("STORAGE_EMULATOR_HOST", cloudStorageOpts.GCPStorageEmulatorHost)
 			if err != nil {
 				return nil, err
 			}
 
-			return newGCPTestCloudStorage(ctx, gcpCredentialsJSON, bucketName)
+			return newGCPTestCloudStorage(ctx, cloudStorageOpts.GCPCredentialsJSON, bucketName)
 		}
 
 		// check that service has been started inside the GCP Kubernetes
 		isOnGCP := compMeta.OnGCE()
 
 		switch {
-		case gcpCredentialsJSON != "":
-			return newExplicitGCPCloudStorage(ctx, gcpCredentialsJSON, bucketName)
+		case cloudStorageOpts.GCPCredentialsJSON != "":
+			return newExplicitGCPCloudStorage(ctx, cloudStorageOpts.GCPCredentialsJSON, bucketName)
 
-		case isOnGCP && gcpCredentialsJSON == "":
+		case isOnGCP && cloudStorageOpts.GCPCredentialsJSON == "":
 			return newImplicitGCPCloudStorage(ctx, bucketName)
 
 		default:
@@ -123,7 +132,25 @@ func newListIterator(f func() (*ListObject, error)) *ListIterator {
 func mergeOpts(opts ...*CloudStorageOption) *CloudStorageOption {
 	cloudStorageOpt := &CloudStorageOption{}
 	for _, opt := range opts {
+		if opt.AWSS3AccessKeyID != "" {
+			cloudStorageOpt.AWSS3AccessKeyID = opt.AWSS3AccessKeyID
+		}
+		if opt.AWSS3SecretAccessKey != "" {
+			cloudStorageOpt.AWSS3SecretAccessKey = opt.AWSS3SecretAccessKey
+		}
+		if opt.AWSS3Region != "" {
+			cloudStorageOpt.AWSS3Region = opt.AWSS3Region
+		}
+		if opt.AWSS3Endpoint != "" {
+			cloudStorageOpt.AWSS3Endpoint = opt.AWSS3Endpoint
+		}
 		cloudStorageOpt.AWSEnableS3Accelerate = opt.AWSEnableS3Accelerate
+		if opt.GCPStorageEmulatorHost != "" {
+			cloudStorageOpt.GCPStorageEmulatorHost = opt.GCPStorageEmulatorHost
+		}
+		if opt.GCPCredentialsJSON != "" {
+			cloudStorageOpt.GCPCredentialsJSON = opt.GCPCredentialsJSON
+		}
 	}
 	return cloudStorageOpt
 }
@@ -191,5 +218,12 @@ type SignedURLOption struct {
 }
 
 type CloudStorageOption struct {
+	AWSS3Endpoint         string
+	AWSS3Region           string
+	AWSS3AccessKeyID      string
+	AWSS3SecretAccessKey  string
 	AWSEnableS3Accelerate bool
+
+	GCPCredentialsJSON     string
+	GCPStorageEmulatorHost string
 }

--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -41,7 +41,7 @@ func NewCloudStorage(
 	gcpCredentialsJSON string,
 	gcpStorageEmulatorHost string,
 ) (CloudStorage, error) {
-	return NewCloudStorageWithOption(ctx, isTesting, bucketProvider, bucketName, &CloudStorageOption{
+	return NewCloudStorageWithOption(ctx, isTesting, bucketProvider, bucketName, CloudStorageOption{
 		AWSS3Endpoint:          awsS3Endpoint,
 		AWSS3Region:            awsS3Region,
 		AWSS3AccessKeyID:       awsS3AccessKeyID,
@@ -53,8 +53,7 @@ func NewCloudStorage(
 }
 
 //nolint:funlen
-func NewCloudStorageWithOption(ctx context.Context, isTesting bool, bucketProvider, bucketName string, opts ...*CloudStorageOption) (CloudStorage, error) {
-	cloudStorageOpts := mergeOpts(opts...)
+func NewCloudStorageWithOption(ctx context.Context, isTesting bool, bucketProvider, bucketName string, cloudStorageOpts CloudStorageOption) (CloudStorage, error) {
 	switch bucketProvider {
 	case "", "aws":
 		// 3-rd party library uses global variables
@@ -127,32 +126,6 @@ func newListIterator(f func() (*ListObject, error)) *ListIterator {
 	return &ListIterator{
 		f: f,
 	}
-}
-
-func mergeOpts(opts ...*CloudStorageOption) *CloudStorageOption {
-	cloudStorageOpt := &CloudStorageOption{}
-	for _, opt := range opts {
-		if opt.AWSS3AccessKeyID != "" {
-			cloudStorageOpt.AWSS3AccessKeyID = opt.AWSS3AccessKeyID
-		}
-		if opt.AWSS3SecretAccessKey != "" {
-			cloudStorageOpt.AWSS3SecretAccessKey = opt.AWSS3SecretAccessKey
-		}
-		if opt.AWSS3Region != "" {
-			cloudStorageOpt.AWSS3Region = opt.AWSS3Region
-		}
-		if opt.AWSS3Endpoint != "" {
-			cloudStorageOpt.AWSS3Endpoint = opt.AWSS3Endpoint
-		}
-		cloudStorageOpt.AWSEnableS3Accelerate = opt.AWSEnableS3Accelerate
-		if opt.GCPStorageEmulatorHost != "" {
-			cloudStorageOpt.GCPStorageEmulatorHost = opt.GCPStorageEmulatorHost
-		}
-		if opt.GCPCredentialsJSON != "" {
-			cloudStorageOpt.GCPCredentialsJSON = opt.GCPCredentialsJSON
-		}
-	}
-	return cloudStorageOpt
 }
 
 // ListIterator iterates over List results.

--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -41,6 +41,38 @@ func NewCloudStorage(
 	gcpCredentialsJSON string,
 	gcpStorageEmulatorHost string,
 ) (CloudStorage, error) {
+	return NewCloudStorageV2(
+		ctx,
+		isTesting,
+		bucketProvider,
+		bucketName,
+
+		awsS3Endpoint,
+		awsS3Region,
+		awsS3AccessKeyID,
+		awsS3SecretAccessKey,
+		false,
+		gcpCredentialsJSON,
+		gcpStorageEmulatorHost,
+	)
+}
+
+//nolint:funlen
+func NewCloudStorageV2(
+	ctx context.Context,
+	isTesting bool,
+	bucketProvider string,
+	bucketName string,
+
+	awsS3Endpoint string,
+	awsS3Region string,
+	awsS3AccessKeyID string,
+	awsS3SecretAccessKey string,
+	awsEnableAccelerateEndpoint bool,
+
+	gcpCredentialsJSON string,
+	gcpStorageEmulatorHost string,
+) (CloudStorage, error) {
 	switch bucketProvider {
 	case "", "aws":
 		// 3-rd party library uses global variables
@@ -63,7 +95,7 @@ func NewCloudStorage(
 			return newAWSTestCloudStorage(ctx, awsS3Endpoint, awsS3Region, bucketName)
 		}
 
-		return newAWSCloudStorage(ctx, awsS3Endpoint, awsS3Region, bucketName)
+		return newAWSCloudStorage(ctx, awsS3Endpoint, awsS3Region, bucketName, awsEnableAccelerateEndpoint)
 
 	case "gcp":
 		if isTesting {


### PR DESCRIPTION
By supporting transfer accelerate option for AWS S3, it could optimize users that far from bucket endpoint doing bucket operation. More info could refer here: https://aws.amazon.com/s3/transfer-acceleration/

Note: currently S3 transfer acceleration only supports for S3 URL using virtual-hosted style, reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-getting-started.html