### PR TITLE
fix: initialize AWS cloud storage with bucketName instead of bucketProvider

### DIFF
--- a/cloud-storage.go
+++ b/cloud-storage.go
@@ -73,10 +73,10 @@ func NewCloudStorageWithOption(ctx context.Context, isTesting bool, bucketProvid
 		}
 
 		if isTesting {
-			return newAWSTestCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketProvider)
+			return newAWSTestCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketName)
 		}
 
-		return newAWSCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketProvider, &cloudStorageOpts.AWSEnableS3Accelerate)
+		return newAWSCloudStorage(ctx, cloudStorageOpts.AWSS3Endpoint, cloudStorageOpts.AWSS3Region, bucketName, &cloudStorageOpts.AWSEnableS3Accelerate)
 
 	case "gcp":
 		if isTesting {


### PR DESCRIPTION
Given this code and remapping in the project that uses this lib `replace github.com/AccelByte/common-blob-go => /root/codes/common-blob-go`:

```go
item, err := list.Next(ctx)
if err == io.EOF {
	break // no more objects
}
fmt.Printf("item %+v %+v\n", item, err)
```

Previous result:

```
item <nil> blob (code=Unknown):
    gocloud.dev/blob.(*ListIterator).Next
        /root/go/pkg/mod/gocloud.dev@v0.25.0/blob/blob.go:448
  - BucketRegionError: incorrect region, the bucket is not in 'us-west-2' region at endpoint ''
        status code: 301, request id: , host id: 
2022/07/25 15:07:12 http: panic serving [::1]:33988: runtime error: invalid memory address or nil pointer dereference
```

Current result:

```
item &{Key:accelbyte_main.json ModTime:2022-07-20 06:51:31 +0000 UTC Size:3440 MD5:[132 147 245 46 148 142 32 62 151 141 20 244 44 162 37 119]} <nil>
item &{Key:accelbyte_theme-five.json ModTime:2022-07-21 15:18:35 +0000 UTC Size:2223 MD5:[127 154 197 72 142 40 151 201 207 43 41 14 245 108 26 116]} <nil>
item &{Key:accelbyte_theme-four.json ModTime:2022-07-21 15:18:36 +0000 UTC Size:2208 MD5:[80 94 36 34 180 252 165 175 26 164 102 213 223 0 117 62]} <nil>
```