### PR TITLE
feat: Support List objects for first level directory only (based on the specified Delimiter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Note: make sure to enable transfer accelerate in S3 bucket, please refer to [thi
 ```go
 type CloudStorage interface {
 	List(ctx context.Context, prefix string) *ListIterator // iterate over all objects in the folder
+	ListWithOptions(ctx context.Context, options *ListOptions) *ListIterator // iterate over objects in the folder based on ListOptions criteria 
 	Get(ctx context.Context, key string) ([]byte, error) // get the object by a name
 	GetReader(ctx context.Context, key string) (io.ReadCloser, error) // get reader to operate with io.ReadCloser
 	Delete(ctx context.Context, key string) error // delete the object by a name
@@ -105,6 +106,33 @@ type CloudStorage interface {
 
         if item.Key == fileName {
             fileFound = true
+        }
+    }
+```
+
+##### ListWithOptions(ctx context.Context, options *ListOptions) *ListIterator
+```go
+    list := storage.CloudStorage.ListWithOptions(parentCtx, &commonblobgo.ListOptions{
+        Prefix:    bucketPrefix,
+
+        // An empty delimiter means that the bucket is treated as a single flat namespace.
+        //
+        // A non-empty delimiter means that any result with the delimiter in its key after Prefix is stripped will be returned with ListObject.IsDir = true,
+        // ListObject.Key truncated after the delimiter. These results represent "directories"
+        Delimiter: "/", 
+    })
+
+    var directories []string
+    for {
+        item, err := list.Next(ctx)
+        if err == io.EOF {
+            break // no more object
+        }
+
+        // ...
+
+        if item.IsDir {
+            directories = append(directories, item.Key)
         }
     }
 ```

--- a/aws-cloud-storage.go
+++ b/aws-cloud-storage.go
@@ -102,6 +102,31 @@ func (ts *AWSCloudStorage) List(
 	})
 }
 
+func (ts *AWSCloudStorage) ListWithOptions(
+	ctx context.Context,
+	listOptions *ListOptions,
+) *ListIterator {
+	iter := ts.bucket.List(&blob.ListOptions{
+		Prefix:    listOptions.Prefix,
+		Delimiter: listOptions.Delimiter,
+	})
+
+	return newListIterator(func() (*ListObject, error) {
+		attrs, err := iter.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ListObject{
+			Key:     attrs.Key,
+			ModTime: attrs.ModTime,
+			Size:    attrs.Size,
+			MD5:     attrs.MD5,
+			IsDir:   attrs.IsDir,
+		}, nil
+	})
+}
+
 func (ts *AWSCloudStorage) Get(
 	ctx context.Context,
 	key string,

--- a/aws-test-cloud-storage.go
+++ b/aws-test-cloud-storage.go
@@ -105,6 +105,31 @@ func (ts *AWSTestCloudStorage) List(
 	})
 }
 
+func (ts *AWSTestCloudStorage) ListWithOptions(
+	ctx context.Context,
+	listOptions *ListOptions,
+) *ListIterator {
+	iter := ts.bucket.List(&blob.ListOptions{
+		Prefix:    listOptions.Prefix,
+		Delimiter: listOptions.Delimiter,
+	})
+
+	return newListIterator(func() (*ListObject, error) {
+		attrs, err := iter.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ListObject{
+			Key:     attrs.Key,
+			ModTime: attrs.ModTime,
+			Size:    attrs.Size,
+			MD5:     attrs.MD5,
+			IsDir:   attrs.IsDir,
+		}, nil
+	})
+}
+
 func (ts *AWSTestCloudStorage) Get(
 	ctx context.Context,
 	key string,

--- a/gcp-cloud-storage-explicit.go
+++ b/gcp-cloud-storage-explicit.go
@@ -126,6 +126,31 @@ func (ts *ExplicitGCPCloudStorage) List(
 	})
 }
 
+func (ts *ExplicitGCPCloudStorage) ListWithOptions(
+	ctx context.Context,
+	listOptions *ListOptions,
+) *ListIterator {
+	iter := ts.bucket.List(&blob.ListOptions{
+		Prefix:    listOptions.Prefix,
+		Delimiter: listOptions.Delimiter,
+	})
+
+	return newListIterator(func() (*ListObject, error) {
+		attrs, err := iter.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ListObject{
+			Key:     attrs.Key,
+			ModTime: attrs.ModTime,
+			Size:    attrs.Size,
+			MD5:     attrs.MD5,
+			IsDir:   attrs.IsDir,
+		}, nil
+	})
+}
+
 func (ts *ExplicitGCPCloudStorage) Get(
 	ctx context.Context,
 	key string,

--- a/gcp-cloud-storage-implicit.go
+++ b/gcp-cloud-storage-implicit.go
@@ -127,6 +127,31 @@ func (ts *ImplicitGCPCloudStorage) List(
 	})
 }
 
+func (ts *ImplicitGCPCloudStorage) ListWithOptions(
+	ctx context.Context,
+	listOptions *ListOptions,
+) *ListIterator {
+	iter := ts.bucket.List(&blob.ListOptions{
+		Prefix:    listOptions.Prefix,
+		Delimiter: listOptions.Delimiter,
+	})
+
+	return newListIterator(func() (*ListObject, error) {
+		attrs, err := iter.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ListObject{
+			Key:     attrs.Key,
+			ModTime: attrs.ModTime,
+			Size:    attrs.Size,
+			MD5:     attrs.MD5,
+			IsDir:   attrs.IsDir,
+		}, nil
+	})
+}
+
 func (ts *ImplicitGCPCloudStorage) Get(
 	ctx context.Context,
 	key string,


### PR DESCRIPTION
The current provided interfaces only support List object for all files inside the specified prefix and go through nested directories, either it’s a directory or file.
e.g. prefix `/directory`

result:
```
/directory/file1
/directory/file2
/directory/subdirectory/file1
/directory/subdirectory/file2
/directory/othersubdirectory/file1
/directory/othersubdirectory/nesteddirectory/file1
```

We need an ability to list the files and directories in the first level only, 
e.g.  prefix `directory/`

result:
```
/directory/file1
/directory/file2
/directory/subdirectory/
/directory/othersubdirectory/
```

Solution:
We will introduce new interface `ListV2` with options parameter to specifiy the `Delimiter`

```
ListWithOptions(ctx context.Context, options *ListOptions) *ListIterator
```

https://accelbyte.atlassian.net/browse/OS-8282